### PR TITLE
Przeskalowano czcionkę, aby karta wzorów mieściła się na jednej kartce

### DIFF
--- a/karta-wzorow.tex
+++ b/karta-wzorow.tex
@@ -55,7 +55,7 @@
 
 \begin{document}
 % Rozmiar czcionki.
-\scalefont{.8}
+\scalefont{.48}
 
 \text{\tiny{
     Wersja z \today\ o \currenttime\ (\pdfmdfivesum file{./karta-wzorow.tex})


### PR DESCRIPTION
Zmieniono skalowanie czcionki z .8 na .48.